### PR TITLE
Add "AT+CEER" in telephony/android_modem

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -1871,6 +1871,14 @@ handleListCurrentCalls( const char*  cmd, AModem  modem )
     return amodem_end_line( modem );
 }
 
+
+static const char*
+handleLastCallFailCause( const char* cmd, AModem modem )
+{
+    amodem_add_line( modem, "+CEER: %d\n", CALL_FAIL_NORMAL );
+    return amodem_end_line( modem );
+}
+
 /* Add a(n unsolicited) time response.
  *
  * retrieve the current time and zone in a format suitable
@@ -2444,6 +2452,7 @@ static const struct {
     { "+COPS=0", NULL, handleOperatorSelection }, /* set network selection to automatic */
     { "!+CMGD=", NULL, handleDeleteSMSonSIM }, /* delete SMS on SIM */
     { "!+CPIN=", NULL, handleChangeOrEnterPIN },
+    { "+CEER", NULL, handleLastCallFailCause },
 
     /* see getSIMStatus() */
     { "+CPIN?", NULL, handleSIMStatusReq },

--- a/telephony/android_modem.h
+++ b/telephony/android_modem.h
@@ -148,6 +148,8 @@ typedef enum {
 
 #define  A_CALL_NUMBER_MAX_SIZE  16
 
+#define CALL_FAIL_NORMAL 16
+
 typedef struct {
     int         id;
     ACallDir    dir;


### PR DESCRIPTION
Bug 768608 - test failure: dom/telephony/test/marionette/*.js | ScriptTimeoutException: timed out
(Add AT+CEER in android_modem)
