### PR TITLE
Bug 785988: Allow setting operator names

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -753,48 +753,65 @@ amodem_set_data_network_type( AModem  modem, ADataNetworkType   type )
 }
 
 int
-amodem_get_operator_name ( AModem  modem, ANameIndex  index, char*  buffer, int  buffer_size )
+amodem_get_operator_name_ex ( AModem  modem, AOperatorIndex  oper_index, ANameIndex  name_index, char*  buffer, int  buffer_size )
 {
     AOperator  oper;
     int        len;
 
-    if ( (unsigned)modem->oper_index >= (unsigned)modem->oper_count ||
-         (unsigned)index > 2 )
+    if ( (unsigned)oper_index >= A_OPERATOR_MAX ||
+         (unsigned)name_index >= A_NAME_MAX )
         return 0;
 
-    oper = modem->operators + modem->oper_index;
-    len  = strlen(oper->name[index]) + 1;
+    oper = modem->operators + oper_index;
+    len  = strlen(oper->name[name_index]) + 1;
 
     if (buffer_size > len)
         buffer_size = len;
 
     if (buffer_size > 0) {
-        memcpy( buffer, oper->name[index], buffer_size-1 );
+        memcpy( buffer, oper->name[name_index], buffer_size-1 );
         buffer[buffer_size] = 0;
     }
     return len;
 }
 
-/* reset one operator name from a user-provided buffer, set buffer_size to -1 for zero-terminated strings */
+int
+amodem_get_operator_name ( AModem  modem, ANameIndex  index, char*  buffer, int  buffer_size )
+{
+    if ( (unsigned)modem->oper_index >= (unsigned)modem->oper_count )
+        return 0;
+
+    return amodem_get_operator_name_ex(modem, modem->oper_index, index, buffer, buffer_size);
+}
+
 void
-amodem_set_operator_name( AModem  modem, ANameIndex  index, const char*  buffer, int  buffer_size )
+amodem_set_operator_name_ex( AModem  modem, AOperatorIndex  oper_index, ANameIndex  name_index, const char*  buffer, int  buffer_size )
 {
     AOperator  oper;
     int        avail;
 
-    if ( (unsigned)modem->oper_index >= (unsigned)modem->oper_count ||
-         (unsigned)index > 2 )
+    if ( (unsigned)oper_index >= A_OPERATOR_MAX ||
+         (unsigned)name_index >= A_NAME_MAX )
         return;
 
-    oper = modem->operators + modem->oper_index;
+    oper = modem->operators + oper_index;
 
     avail = sizeof(oper->name[0]);
     if (buffer_size < 0)
         buffer_size = strlen(buffer);
     if (buffer_size > avail-1)
         buffer_size = avail-1;
-    memcpy( oper->name[index], buffer, buffer_size );
-    oper->name[index][buffer_size] = 0;
+    memcpy( oper->name[name_index], buffer, buffer_size );
+    oper->name[name_index][buffer_size] = 0;
+}
+
+void
+amodem_set_operator_name( AModem  modem, ANameIndex  index, const char*  buffer, int  buffer_size )
+{
+    if ( (unsigned)modem->oper_index >= (unsigned)modem->oper_count )
+        return;
+
+    amodem_set_operator_name_ex(modem, modem->oper_index, index, buffer, buffer_size);
 }
 
 /** CALLS

--- a/telephony/android_modem.h
+++ b/telephony/android_modem.h
@@ -107,6 +107,14 @@ extern void                amodem_set_cdma_subscription_source( AModem modem, AC
 extern void                amodem_set_cdma_prl_version( AModem modem, int prlVersion);
 
 
+/** OPERATOR TYPES
+ **/
+typedef enum {
+    A_OPERATOR_HOME = 0,
+    A_OPERATOR_ROAMING,
+    A_OPERATOR_MAX  /* don't remove */
+} AOperatorIndex;
+
 /** OPERATOR NAMES
  **/
 typedef enum {
@@ -116,11 +124,15 @@ typedef enum {
     A_NAME_MAX  /* don't remove */
 } ANameIndex;
 
-/* retrieve operator name into user-provided buffer. returns number of writes written, including terminating zero */
+/* retrieve current operator name into user-provided buffer. returns number of writes written, including terminating zero */
 extern int   amodem_get_operator_name ( AModem  modem, ANameIndex  index, char*  buffer, int  buffer_size );
+/* retrieve specified operator name into user-provided buffer. returns number of writes written, including terminating zero */
+extern int   amodem_get_operator_name_ex ( AModem  modem, AOperatorIndex, ANameIndex  index, char*  buffer, int  buffer_size );
 
-/* reset one operator name from a user-provided buffer, set buffer_size to -1 for zero-terminated strings */
+/* reset one current operator name from a user-provided buffer, set buffer_size to -1 for zero-terminated strings */
 extern void  amodem_set_operator_name( AModem  modem, ANameIndex  index, const char*  buffer, int  buffer_size );
+/* reset one specified operator name from a user-provided buffer, set buffer_size to -1 for zero-terminated strings */
+extern void  amodem_set_operator_name_ex( AModem  modem, AOperatorIndex, ANameIndex  index, const char*  buffer, int  buffer_size );
 
 /** CALL STATES
  **/


### PR DESCRIPTION
Bug [785988](https://bugzilla.mozilla.org/show_bug.cgi?id=785988) deals empty carrier long/short names and need some way to test it.
