### PR TITLE
Bug 790463: Fix crash caused by missing call states

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -2155,6 +2155,18 @@ voice_call_event( void*  _vcall )
             call->state = A_CALL_ACTIVE;
             break;
 
+        case A_CALL_ACTIVE:
+            break;
+
+        case A_CALL_HELD:
+            break;
+
+        case A_CALL_INCOMING:
+            break;
+
+        case A_CALL_WAITING:
+            break;
+
         default:
             assert( 0 && "unreachable event call state" );
     }


### PR DESCRIPTION
Please reference https://bugzilla.mozilla.org/show_bug.cgi?id=790463

There is an automatically call state transition mechanism in emulator.
1. After handleDial(), the call state changed to A_CALL_DIALING and a timer (one second) initiated state transition. 
2. Timeout function voice_call_event() called, and call state changed to A_CALL_ALERTING, and another timer (one second) initiated for next state transition.
3. Timeout function voice_call_event() called, and call state changed to A_CALL_ACTIVE.

During the automatically state transition period, it's possible call state been changed by console commands (ex: 'gsm accept' or 'gsm hold') for testing purpose.  We should not assert on these states.
