### PR TITLE
Bug 821605: Adding EF_SPDI file and enabling SPDI in SST.

### DIFF
--- a/telephony/sim_card.c
+++ b/telephony/sim_card.c
@@ -360,10 +360,10 @@ asimcard_io( ASimCard  sim, const char*  cmd )
         { "+CRSM=176,28435,0,0,1",  "+CRSM: 144,0,55" },
 
         // SIM Service Table(6F38):
-        //   Enabled: 1..4, 7, 9..19, 26, 27, 29, 38, 51..55
+        //   Enabled: 1..4, 7, 9..19, 26, 27, 29, 38, 51..56
         // @see 3GPP TS 51.011 section 10.3.7 EFsst (SIM Service Table)
         { "+CRSM=192,28472,0,0,15", "+CRSM: 144,0,0000000f6f3804001aa0aa01020000" },
-        { "+CRSM=176,28472,0,0,15", "+CRSM: 144,0,ff30ffff3f003c03000c0000f03f00" },
+        { "+CRSM=176,28472,0,0,15", "+CRSM: 144,0,ff30ffff3f003c03000c0000f0ff00" },
 
         // Mailbox Identifier(6FC9):
         //   Mailbox Dialing Number Identifier - Voicemail:      1
@@ -427,10 +427,14 @@ asimcard_io( ASimCard  sim, const char*  cmd )
         { "+CRSM=176,28486,0,0,17", "+CRSM: 144,0,01416e64726f6964ffffffffffffffffff" },
 
         // Service Provider Display Information(6FCD):
-        //   Always return SW1=0x94, SW2=0x04, which means "file ID not found".
+        //   SPDI TLV (tag = 'a3')
+        //     SPDI TLV (tag = '80')
+        //       PLMN: 234136
+        //       PLMN: 46692
         // @see 3GPP TS 31.102 section 4.2.66 EFspdi (Service Provider Display Information)
         // @see 3GPP TS 51.011 section 9.4.4 Referencing Management
-        { "+CRSM=192,28621,0,0,15", "+CRSM: 148,4" },
+        { "+CRSM=192,28621,0,0,15", "+CRSM: 144,0,0000000d6fcd04000aa0aa01020000" },
+        { "+CRSM=176,28621,0,0,13", "+CRSM: 144,0,a30b800932643164269fffffff" },
 
         // PLMN Network Name(6FC5):
         //   FIXME:


### PR DESCRIPTION
Adding EF_SPDI file, which contains an SPDI TLV (tag: A3) and an Service Provider PLMN List TLV that contains 2 entry: 234136 and 46692.
