### PR TITLE
Bug 828633 - fix remote phone number parsing

### DIFF
--- a/telephony/remote_call.c
+++ b/telephony/remote_call.c
@@ -105,7 +105,7 @@ remote_number_string_to_port( const char*  number, AModem  modem, int*  port, in
         len--;
     if (len == 11 && (!memcmp(number, PHONE_PREFIX, 6)
             && ((number[6] - '1') == amodem_get_instance_id(modem)))) {
-        temp += 7;
+        temp += 6;
     }
     num = strtol( temp, &end, 10 );
 


### PR DESCRIPTION
After merging MultiSIM, remote phone number parsing should take last 5 digits rather than 4 ones. This causes all **remote_number_string_to_port()** calls return a negative value meaning invalid remote number, and fails all remote phone number related functions like SMS loopback, etc. See [Bug 828633](https://bugzilla.mozilla.org/show_bug.cgi?id=828633).
