### PR TITLE
Bug 860682 - Support getting remaining PIN retries

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -1943,6 +1943,26 @@ handleChangeOrEnterPIN( const char*  cmd, AModem  modem )
 
 
 static const char*
+handleGetRemainingRetries( const char* cmd, AModem modem )
+{
+    assert(!memcmp(cmd, "+CPINR=", 7));
+    cmd += 7;
+
+    amodem_begin_line(modem);
+
+    if (!strcmp(cmd, "SIM PIN")) {
+      amodem_add_line(modem, "+CPINR: SIM PIN,%d,%d\r\n",
+                      asimcard_get_pin_retries(modem->sim),
+                      A_SIM_PIN_RETRIES);
+    } else {
+      // Incorrect parameters
+      amodem_add_line( modem, "+CME ERROR: 50\r\n");
+    }
+
+    return amodem_end_line(modem);
+}
+
+static const char*
 handleListCurrentCalls( const char*  cmd, AModem  modem )
 {
     int  nn;
@@ -2551,6 +2571,7 @@ static const struct {
     { "+COPS=0", NULL, handleOperatorSelection }, /* set network selection to automatic */
     { "!+CMGD=", NULL, handleDeleteSMSonSIM }, /* delete SMS on SIM */
     { "!+CPIN=", NULL, handleChangeOrEnterPIN },
+    { "!+CPINR=", NULL, handleGetRemainingRetries }, /* get remaining PIN retries*/
     { "+CEER", NULL, handleLastCallFailCause },
 
     /* see getSIMStatus() */

--- a/telephony/sim_card.h
+++ b/telephony/sim_card.h
@@ -14,6 +14,9 @@
 
 #include "gsm.h"
 
+#define  A_SIM_PIN_RETRIES 3
+#define  A_SIM_PUK_RETRIES 6
+
 typedef struct ASimCardRec_*    ASimCard;
 
 extern ASimCard  asimcard_create( int base_port , int instance_id);
@@ -38,6 +41,8 @@ extern void         asimcard_set_puk( ASimCard  sim, const char*  puk );
 
 extern int         asimcard_check_pin( ASimCard  sim, const char*  pin );
 extern int         asimcard_check_puk( ASimCard  sim, const char*  puk, const char*  pin );
+
+extern int         asimcard_get_pin_retries( ASimCard  sim );
 
 /* Restricted SIM Access command, as defined by 8.18 of 3GPP 27.007 */
 typedef enum {


### PR DESCRIPTION
Please see [bug 860682](https://bugzilla.mozilla.org/show_bug.cgi?id=860682)

Implement AT+CPINR to get remaining PIN retries. (TS 127.007 session 8.65)
