### PR TITLE
Bug 869327 - B2G Emulator: Upgrade hardware/ril, external/qemu to include RILv7/CDMA

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -2352,7 +2352,7 @@ handleSignalStrength( const char*  cmd, AModem  modem )
     int ber = modem->ber;
     rssi = (0 > rssi && rssi > 31) ? 99 : rssi ;
     ber = (0 > ber && ber > 7 ) ? 99 : ber;
-    amodem_add_line( modem, "+CSQ: %i,%i\r\n", rssi, ber );
+    amodem_add_line( modem, "+CSQ: %i,%i,85,130,90,6,4,25,9,50,68,12\r\n", rssi, ber );
     return amodem_end_line( modem );
 }
 


### PR DESCRIPTION
Cherry pick a patch for signal strength. 
Please see [bug 869327 comment #2](https://bugzilla.mozilla.org/show_bug.cgi?id=869327#c2) for more detailed information.
