### PR TITLE
Bug 870422 (follow-up): fix cpu abort in `goldfish_device_set_irq`.

### DIFF
--- a/hw/goldfish_tty.c
+++ b/hw/goldfish_tty.c
@@ -55,7 +55,7 @@ static void goldfish_tty_update_irq(struct tty_state *s)
     level = (s_tty.int_mask & s_tty.int_active) ? 1 : 0;
     if (level != current_level) {
         current_level = level;
-        goldfish_device_set_irq(&s->dev, s->dev.irq, level);
+        goldfish_device_set_irq(&s->dev, 0, level);
     }
 }
 


### PR DESCRIPTION
The 2nd param of `goldfish_device_set_irq()` is the nth IRQ owned by
the device, not the global IRQ number.
