### PR TITLE
Revert "Bug 876369 - Part 5: Use amodem_nvram_set to set and save nvram ...

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -100,7 +100,6 @@ int amodem_num_devices = 0;
 static int _amodem_switch_technology(AModem modem, AModemTech newtech, int32_t newpreferred);
 static int _amodem_set_cdma_subscription_source( AModem modem, ACdmaSubscriptionSource ss);
 static int _amodem_set_cdma_prl_version( AModem modem, int prlVersion);
-static int amodem_nvram_set( AModem modem, const char *name, const char *value );
 
 #if DEBUG
 static const char*  quote( const char*  line )
@@ -453,7 +452,8 @@ amodem_load_nvram( AModem modem )
     D("Using config file: %s\n", modem->nvram_config_filename);
     if (aconfig_load_file(root, modem->nvram_config_filename)) {
         D("Unable to load config\n");
-        amodem_nvram_set(modem, NV_MODEM_TECHNOLOGY, "gsm");
+        aconfig_set(root, NV_MODEM_TECHNOLOGY, "gsm");
+        aconfig_save_file(root, modem->nvram_config_filename);
     }
     return root;
 }
@@ -1373,7 +1373,8 @@ handleRoamPref( const char * cmd, AModem modem )
          // (if *endptr is null, it means strtol processed the whole string as a number)
         if(endptr && !*endptr) {
             modem->roaming_pref = roaming_pref;
-            amodem_nvram_set( modem, NV_CDMA_ROAMING_PREF, cmd );
+            aconfig_set( modem->nvram_config, NV_CDMA_ROAMING_PREF, cmd );
+            aconfig_save_file( modem->nvram_config, modem->nvram_config_filename );
             return NULL;
         }
     }


### PR DESCRIPTION
...config"

`amodem_nvram_set()` depends on `modem->nvram_config` being set
previously, but it's actually set by the return value of
`amodem_load_nvram`.  So `modem->nvram_config` is not yet initialized
here and traps emulator with segmentation fault.

Commit aece119 was meant to share common code for saving nvram
configs. It only replaces lines in two places, inclusive of
`amodem_load_nvram`.  Since we shouldn't call `amodem_nvram_set()`
here, leaving sharing common code a meaningless thing, we should
revert it instead.

This reverts commit aece119472ba3509202de0d2b25167b1237cd0c2.
