### PR TITLE
Bug 868896: Support AT+CPINR for PUK locks

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -2049,6 +2049,10 @@ handleGetRemainingRetries( const char* cmd, AModem modem )
       amodem_add_line(modem, "+CPINR: SIM PIN,%d,%d\r\n",
                       asimcard_get_pin_retries(modem->sim),
                       A_SIM_PIN_RETRIES);
+    } else if (!strcmp(cmd, "SIM PUK")) {
+      amodem_add_line(modem, "+CPINR: SIM PUK,%d,%d\r\n",
+                      asimcard_get_puk_retries(modem->sim),
+                      A_SIM_PUK_RETRIES);
     } else {
       // Incorrect parameters
       amodem_add_line( modem, "+CME ERROR: 50\r\n");

--- a/telephony/sim_card.c
+++ b/telephony/sim_card.c
@@ -198,6 +198,12 @@ asimcard_get_pin_retries( ASimCard sim )
     return A_SIM_PIN_RETRIES - sim->pin_retries;
 }
 
+int
+asimcard_get_puk_retries( ASimCard sim )
+{
+    return A_SIM_PUK_RETRIES - sim->puk_retries;
+}
+
 typedef enum {
     SIM_FILE_DM = 0,
     SIM_FILE_DF,

--- a/telephony/sim_card.h
+++ b/telephony/sim_card.h
@@ -43,6 +43,7 @@ extern int         asimcard_check_pin( ASimCard  sim, const char*  pin );
 extern int         asimcard_check_puk( ASimCard  sim, const char*  puk, const char*  pin );
 
 extern int         asimcard_get_pin_retries( ASimCard  sim );
+extern int         asimcard_get_puk_retries( ASimCard  sim );
 
 /* Restricted SIM Access command, as defined by 8.18 of 3GPP 27.007 */
 typedef enum {


### PR DESCRIPTION
This patch adds support 'SIM PUK' to the AT command +CPINR in
the emulator. Most of the necessary infrastructure is already
in place.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
