### PR TITLE
Bug 837448 - fix comparing garbage data in sms_address_eq. r=hsinyi

### DIFF
--- a/telephony/sms.c
+++ b/telephony/sms.c
@@ -473,7 +473,7 @@ sms_address_eq( const SmsAddressRec*  addr1, const SmsAddressRec*  addr2 )
          addr1->len != addr2->len )
         return 0;
 
-    return ( !memcmp( addr1->data, addr2->data, addr1->len ) );
+    return ( !memcmp( addr1->data, addr2->data, (addr1->len + 1) / 2) );
 }
 
 /** SMS PARSER


### PR DESCRIPTION
The |addr1->len| is the number of digits, and SMS-ADDRESS packs two
digits into one octet.  So sometimes the garbage data at the end fail
the comparison, which in turn fails |sms_receiver_find_p()|, and then
results in a new fragment created with wrong parameter.
