### PR TITLE
Added command 'report' to console

### DIFF
--- a/android/console.c
+++ b/android/console.c
@@ -1589,6 +1589,36 @@ do_gsm_signal( ControlClient  client, char*  args )
       return 0;
   }
 
+static void
+do_gsm_report_creg( ControlClient  client, char*  args)
+{
+    ARegistrationUnsolMode creg = amodem_get_voice_unsol_mode(client->modem);
+
+    control_write( client, "+CREG: %d\r\n", creg);
+}
+
+static int
+do_gsm_report( ControlClient  client, char*  args )
+{
+    char* field;
+
+    if (args) {
+        field = strsep(&args, " ");
+    } else {
+        field = NULL;
+    }
+
+    do {
+        if (!field || !strcmp(field, "creg")) {
+            do_gsm_report_creg(client, args);
+            if (field) {
+                break;
+            }
+        }
+    } while (field);
+
+    return 0;
+}
 
 #if 0
 static const CommandDefRec  gsm_in_commands[] =
@@ -1678,6 +1708,11 @@ static const CommandDefRec  gsm_commands[] =
     "'gsm location [<lac> <ci>]' sets or gets the location area code and cell identification.\r\n"
     "lac range is 0..65535 and ci range is 0..268435455\r\n",
     NULL, do_gsm_location, NULL},
+
+    { "report", "report Modem status",
+    "'gsm report'      report all known fields\r\n"
+    "'gsm report creg' report CREG field\r\n",
+    NULL, do_gsm_report, NULL},
 
     { NULL, NULL, NULL, NULL, NULL, NULL }
 };

--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -253,13 +253,6 @@ android_parse_network_type( const char*  speed )
     return A_DATA_NETWORK_GPRS;
 }
 
-/* 'mode' for +CREG/+CGREG commands */
-typedef enum {
-    A_REGISTRATION_UNSOL_DISABLED     = 0,
-    A_REGISTRATION_UNSOL_ENABLED      = 1,
-    A_REGISTRATION_UNSOL_ENABLED_FULL = 2
-} ARegistrationUnsolMode;
-
 /* Operator selection mode, see +COPS commands */
 typedef enum {
     A_SELECTION_AUTOMATIC,
@@ -796,6 +789,12 @@ ARegistrationState
 amodem_get_voice_registration( AModem  modem )
 {
     return modem->voice_state;
+}
+
+ARegistrationUnsolMode
+amodem_get_voice_unsol_mode( AModem  modem )
+{
+    return modem->voice_mode;
 }
 
 void

--- a/telephony/android_modem.h
+++ b/telephony/android_modem.h
@@ -57,6 +57,13 @@ extern ASimCard    amodem_get_sim( AModem  modem );
 /** VOICE AND DATA NETWORK REGISTRATION
  **/
 
+/* 'mode' for +CREG/+CGREG commands */
+typedef enum {
+    A_REGISTRATION_UNSOL_DISABLED     = 0,
+    A_REGISTRATION_UNSOL_ENABLED      = 1,
+    A_REGISTRATION_UNSOL_ENABLED_FULL = 2
+} ARegistrationUnsolMode;
+
 /* 'stat' for +CREG/+CGREG commands */
 typedef enum {
     A_REGISTRATION_UNREGISTERED = 0,
@@ -112,6 +119,8 @@ typedef enum {
     A_ROAMING_PREF_ANY,
     A_ROAMING_PREF_UNKNOWN // This must always be the last value in the enum
 } ACdmaRoamingPref;
+
+extern ARegistrationUnsolMode  amodem_get_voice_unsol_mode( AModem  modem );
 
 extern ARegistrationState  amodem_get_voice_registration( AModem  modem );
 extern void                amodem_set_voice_registration( AModem  modem, ARegistrationState    state );


### PR DESCRIPTION
The report command returns internal state of the GSM modem. The only
supported command for now is 'creg' for the network-registration state.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
