### PR TITLE
Bug 860696 - Add emulator commands for Bluetooth test

### DIFF
--- a/hw/bt.h
+++ b/hw/bt.h
@@ -109,6 +109,14 @@ void bt_device_done(struct bt_device_s *dev);
 
 /* bt-hci.c */
 struct HCIInfo *bt_new_hci(struct bt_scatternet_s *net);
+bool bt_add_remote(struct HCIInfo *info, char *address);
+void bt_remove_remote(struct HCIInfo *info, char *address);
+void bt_remove_all_remotes(struct HCIInfo *info);
+bool bt_set_remote_property(
+    struct HCIInfo *info, char *address, char *property, char *value);
+bool bt_get_local_property(struct HCIInfo *info, char *property, char *ret);
+bool bt_get_remote_property(
+    struct HCIInfo *info, char *address, char *property, char *ret);
 
 /* bt-vhci.c */
 void bt_vhci_init(struct HCIInfo *info);

--- a/hw/goldfish_bt.c
+++ b/hw/goldfish_bt.c
@@ -265,3 +265,38 @@ goldfish_bt_new_cs(struct HCIInfo *hci)
 
     return cs;
 }
+
+bool goldfish_bt_add_remote(char *address)
+{
+    ABluetooth bt = &_android_bluetooth[0];
+    return bt_add_remote(bt->hci, address);
+}
+
+void goldfish_bt_remove_remote(char *address)
+{
+    ABluetooth bt = &_android_bluetooth[0];
+
+    if (!strcmp(address, "all")) {
+        bt_remove_all_remotes(bt->hci);
+    } else {
+        bt_remove_remote(bt->hci, address);
+    }
+}
+
+bool goldfish_bt_set_remote_property(char *address, char *property, char *value)
+{
+    ABluetooth bt = &_android_bluetooth[0];
+    return bt_set_remote_property(bt->hci, address, property, value);
+}
+
+bool goldfish_bt_get_property(char *address, char *property, char *ret)
+{
+    ABluetooth bt = &_android_bluetooth[0];
+
+    if (!strcmp(address, "local")) {
+        return bt_get_local_property(bt->hci, property, ret);
+    } else {
+        return bt_get_remote_property(bt->hci, address, property, ret);
+    }
+}
+

--- a/hw/goldfish_bt.h
+++ b/hw/goldfish_bt.h
@@ -17,6 +17,12 @@ typedef enum {
 
 /* hw/goldfish_bt.c */
 CharDriverState* goldfish_bt_new_cs (struct HCIInfo *hci);
+bool             goldfish_bt_add_remote (char *address);
+void             goldfish_bt_remove_remote (char *address);
+bool             goldfish_bt_set_remote_property (
+                     char *address, char *property, char *value);
+bool             goldfish_bt_get_property (
+                     char *address, char *property, char *ret);
 
 /* hw/goldfish_rfkill.c */
 uint32_t android_rfkill_get_blocking();


### PR DESCRIPTION
Add 4 emulator bt commands for control clients establishing
the test environment (bt add-remote, bt remove-remote, bt set
and bt get)
