### PR TITLE
Bug 860696 - Add emulator commands for Bluetooth test

### DIFF
--- a/hw/bt-hci.c
+++ b/hw/bt-hci.c
@@ -2219,3 +2219,173 @@ static void bt_hci_done(struct HCIInfo *info)
 
     qemu_free(hci);
 }
+
+static void str_to_bdaddr(const char *addr, bdaddr_t *ret)
+{
+    sscanf(addr, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+           &ret->b[5], &ret->b[4], &ret->b[3],
+           &ret->b[2], &ret->b[1], &ret->b[0]);
+}
+
+static void bdaddr_to_str(const bdaddr_t *addr, char *ret)
+{
+    sprintf(ret, "%02x:%02x:%02x:%02x:%02x:%02x",
+            (int)addr->b[5],(int)addr->b[4],(int)addr->b[3],
+            (int)addr->b[2],(int)addr->b[1],(int)addr->b[0]);
+}
+
+static struct bt_device_s* find_remote(struct bt_scatternet_s *net,
+                                       const bdaddr_t *addr)
+{
+    struct bt_device_s* slave = net->slave;
+    while (slave) {
+        if (!bacmp(&slave->bd_addr, addr))
+            return slave;
+
+        slave = slave->next;
+    }
+
+    return NULL;
+}
+
+bool bt_add_remote(struct HCIInfo *info, char *address)
+{
+    struct bt_hci_s* hci = hci_from_info(info);
+
+    bdaddr_t addr;
+    str_to_bdaddr(address, &addr);
+
+    if (find_remote(hci->device.net, &addr)) {
+        /* Device already exists */
+        return false;
+    }
+
+    struct bt_device_s* remote = qemu_mallocz(sizeof(struct bt_device_s));
+    memset(remote, 0, sizeof(*remote));
+    bacpy(&remote->bd_addr, &addr);
+
+    /* Default: enable inquiry scan and page scan */
+    remote->inquiry_scan = 1;
+    remote->page_scan = 1;
+
+    /* Simple slave-only devices need to implement only .lmp_acl_data */
+    remote->lmp_acl_data = bt_hci_lmp_acl_data_slave;
+
+    remote->net = hci->device.net;
+    remote->next = NULL;
+
+    /* Append remote to the scatternet */
+    struct bt_device_s* slave = hci->device.net->slave;
+    if (!slave)
+        /* Actually this is impossible. The first device on the statternet
+         * must be the host itself. */
+        return false;
+
+    while (slave->next)
+        slave = slave->next;
+    slave->next = remote;
+
+    return true;
+}
+
+void bt_remove_remote(struct HCIInfo *info, char *address)
+{
+    struct bt_hci_s* hci = hci_from_info(info);
+    struct bt_device_s* prev_slave = hci->device.net->slave;
+    struct bt_device_s* slave = hci->device.net->slave->next;
+
+    bdaddr_t addr;
+    str_to_bdaddr(address, &addr);
+
+    /* The first slave in the slave linked list should be the local device. */
+    /* Therefore start from the second slave.                               */
+    while (slave) {
+        if (!bacmp(&slave->bd_addr, &addr)) {
+            prev_slave->next = slave->next;
+
+            if (slave->lmp_name) {
+                qemu_free((void *) slave->lmp_name);
+            }
+            qemu_free(slave);
+            break;
+        }
+
+        prev_slave = slave;
+        slave = slave->next;
+    }
+}
+
+void bt_remove_all_remotes(struct HCIInfo *info)
+{
+    struct bt_hci_s* hci = hci_from_info(info);
+
+    /* The first slave in the slave linked list should be the local device. */
+    /* Therefore start from the second slave.                               */
+    struct bt_device_s* slave = hci->device.net->slave->next;
+
+    while (slave) {
+        struct bt_device_s* next = slave->next;
+
+        if (slave->lmp_name)
+            qemu_free((void *) slave->lmp_name);
+        qemu_free(slave);
+
+        slave = next;
+    }
+
+    /* Keep local device and clear all slaves by setting next to NULL */
+    hci->device.net->slave->next = NULL;
+}
+
+bool bt_set_remote_property(
+    struct HCIInfo *info, char *address, char *property, char *value)
+{
+    bdaddr_t addr;
+    str_to_bdaddr(address, &addr);
+
+    struct bt_hci_s* hci = hci_from_info(info);
+    struct bt_device_s* slave = find_remote(hci->device.net, &addr);
+
+    if (!slave) {
+      fprintf(stderr, "Requested remote device doesn't exist.\n");
+      return false;
+    }
+
+    return bt_device_set_property(slave, property, value);
+}
+
+bool bt_get_remote_property(
+    struct HCIInfo *info, char *address, char *property, char *ret)
+{
+    bdaddr_t addr;
+    str_to_bdaddr(address, &addr);
+
+    struct bt_hci_s* hci = hci_from_info(info);
+    struct bt_device_s* slave = find_remote(hci->device.net, &addr);
+
+    if (!slave) {
+        fprintf(stderr, "Requested remote device doesn't exist.\n");
+        return false;
+    }
+
+    return bt_device_get_property(slave, property, ret);
+}
+
+bool bt_get_local_property(struct HCIInfo *info, char *property, char *ret)
+{
+    struct bt_hci_s* hci = hci_from_info(info);
+    struct bt_device_s* host = &hci->device;
+
+    if (!strcmp(property, "address")) {
+        bdaddr_to_str(&host->bd_addr, ret);
+    } else if (!strcmp(property, "discovering")) {
+        strcpy(ret, (hci->lm.inquire || hci->lm.periodic) ? "true" : "false");
+    } else {
+        // Common properties (cod, name, discoverable) would be handled here
+        return bt_device_get_property(host, property, ret);
+    }
+
+    return true;
+}
+
+

--- a/hw/bt.h
+++ b/hw/bt.h
@@ -106,9 +106,23 @@ struct bt_device_s {
 /* bt.c */
 void bt_device_init(struct bt_device_s *dev, struct bt_scatternet_s *net);
 void bt_device_done(struct bt_device_s *dev);
+bool bt_device_get_property(
+    struct bt_device_s *dev, const char *property, char *ret);
+bool bt_device_set_property(
+    struct bt_device_s *dev, const char *property, char *value);
 
 /* bt-hci.c */
+#define MAX_BD_NAME_SIZE 248
+
 struct HCIInfo *bt_new_hci(struct bt_scatternet_s *net);
+bool bt_add_remote(struct HCIInfo *info, char *address);
+void bt_remove_remote(struct HCIInfo *info, char *address);
+void bt_remove_all_remotes(struct HCIInfo *info);
+bool bt_set_remote_property(
+    struct HCIInfo *info, char *address, char *property, char *value);
+bool bt_get_local_property(struct HCIInfo *info, char *property, char *ret);
+bool bt_get_remote_property(
+    struct HCIInfo *info, char *address, char *property, char *ret);
 
 /* bt-vhci.c */
 void bt_vhci_init(struct HCIInfo *info);

--- a/hw/goldfish_bt.c
+++ b/hw/goldfish_bt.c
@@ -265,3 +265,38 @@ goldfish_bt_new_cs(struct HCIInfo *hci)
 
     return cs;
 }
+
+bool goldfish_bt_add_remote(char *address)
+{
+    ABluetooth bt = &_android_bluetooth[0];
+    return bt_add_remote(bt->hci, address);
+}
+
+void goldfish_bt_remove_remote(char *address)
+{
+    ABluetooth bt = &_android_bluetooth[0];
+
+    if (!strcmp(address, "all")) {
+        bt_remove_all_remotes(bt->hci);
+    } else {
+        bt_remove_remote(bt->hci, address);
+    }
+}
+
+bool goldfish_bt_set_remote_property(char *address, char *property, char *value)
+{
+    ABluetooth bt = &_android_bluetooth[0];
+    return bt_set_remote_property(bt->hci, address, property, value);
+}
+
+bool goldfish_bt_get_property(char *address, char *property, char *ret)
+{
+    ABluetooth bt = &_android_bluetooth[0];
+
+    if (!strcmp(address, "local")) {
+        return bt_get_local_property(bt->hci, property, ret);
+    } else {
+        return bt_get_remote_property(bt->hci, address, property, ret);
+    }
+}
+

--- a/hw/goldfish_bt.h
+++ b/hw/goldfish_bt.h
@@ -17,6 +17,12 @@ typedef enum {
 
 /* hw/goldfish_bt.c */
 CharDriverState* goldfish_bt_new_cs (struct HCIInfo *hci);
+bool             goldfish_bt_add_remote (char *address);
+void             goldfish_bt_remove_remote (char *address);
+bool             goldfish_bt_set_remote_property (
+                     char *address, char *property, char *value);
+bool             goldfish_bt_get_property (
+                     char *address, char *property, char *ret);
 
 /* hw/goldfish_rfkill.c */
 uint32_t android_rfkill_get_blocking();


### PR DESCRIPTION
This is v2 patch. All comments for v1 have been taken.

Add 4 emulator bt commands for control clients establishing
the test environment (bt add-remote, bt remove-remote, bt set
and bt get)
