### PR TITLE
Bug 984318 - [B2G] [Emulator] MAX_CALLS should be 7 (on gsm)

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -302,7 +302,13 @@ typedef struct {
 
 /* the spec says that there can only be a max of 4 contexts */
 #define  MAX_DATA_CONTEXTS  4
-#define  MAX_CALLS          4
+/* According to 3GPP 22.083 clause 2.2.1, 3GPP 22.084 clause 1.2.1 and 3GPP
+ * 22.030 clause 6.5.5.6, the case of the maximum number is reached "when
+ * there comes an incoming call while we have already one active(held)
+ * conference call (with 5 remote parties) and one held(active) single call."
+ * The maximum number of voice calls is therefore 7.
+ */
+#define  MAX_CALLS          7
 #define  MAX_EMERGENCY_NUMBERS 16
 
 


### PR DESCRIPTION
Considering gsm network, we could have at maximum one single call and one conference call (up to 5 participants) at the same time. So MAX_CALLS should be 6.
