### PR TITLE
Bug 1007535 - Add new console command, "ussd unsol", to generate USSD uns...

### DIFF
--- a/android/console.c
+++ b/android/console.c
@@ -3798,6 +3798,76 @@ static const CommandDefRec bt_commands[] =
 /********************************************************************************************/
 /********************************************************************************************/
 /*****                                                                                 ******/
+/*****                           U S S D   C O M M A N D S                             ******/
+/*****                                                                                 ******/
+/********************************************************************************************/
+/********************************************************************************************/
+
+static void
+help_ussd_unsol( ControlClient  client )
+{
+    control_write( client,
+        "'ussd unsol <type> <message_str>': allows you to generate ussd unsolicted response.\r\n\r\n"
+        "valid values for <type> are the following:\r\n\r\n"
+        "  0: no further user action required\r\n"
+        "  1: further user action required\r\n"
+        "  2: USSD terminated bu network\r\n"
+        "  3: other local client has responded\r\n"
+        "  4: operation not supported\r\n"
+        "  5: network time out\r\n" );
+}
+
+static int
+do_ussd_unsol( ControlClient client, char* args )
+{
+    char* pnext = NULL;
+    char* end = NULL;
+    int type = -1;
+
+    if (!client->modem) {
+        control_write(client, "KO: modem emulation not running\r\n");
+        return -1;
+    }
+
+    if (!args) {
+        control_write(client, "KO: missing argument, try 'stk unsol <type> <message_str>'\r\n");
+        return -1;
+    }
+
+    // Parse <type>
+    pnext = strchr(args, ' ');
+    type = strtol(args, &end, 10);
+    if (end != pnext || type < 0 || type > 5) {
+        // first argument is not a number or out of range.
+        control_write(client, "KO: bad argument, try 'help ussd unsol' for list of valid values\r\n");
+        return -1;
+    }
+
+    // Get <message_str>
+    while (*pnext && isspace(*pnext)) pnext++;
+    if (!*pnext) {
+        // should have two arguments.
+        control_write(client, "KO: missing argument, try 'stk unsol <type> <message_str>'\r\n");
+        return -1;
+    }
+
+    // Send ussd response
+    amodem_send_ussd_unsol_response(client->modem, type, pnext);
+
+    return 0;
+}
+
+static const CommandDefRec ussd_commands[] =
+{
+    { "unsol", "generate ussd unsolicted response\r\n",
+      NULL, help_ussd_unsol, do_ussd_unsol, NULL },
+
+    { NULL, NULL, NULL, NULL, NULL, NULL }
+};
+
+/********************************************************************************************/
+/********************************************************************************************/
+/*****                                                                                 ******/
 /*****                           M A I N   C O M M A N D S                             ******/
 /*****                                                                                 ******/
 /********************************************************************************************/
@@ -4203,6 +4273,10 @@ static const CommandDefRec   main_commands[] =
     { "bt", "Bluetooth related commands",
       "allows you to retrieve BT status or add/remove remote devices\r\n", NULL,
       NULL, bt_commands },
+
+    { "ussd", "USSD related commands",
+      "allows you to simulate an inbound USSD response\r\n", NULL,
+      NULL, ussd_commands },
 
     { NULL, NULL, NULL, NULL, NULL, NULL }
 };

--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -1202,6 +1202,12 @@ amodem_send_stk_unsol_proactive_command( AModem  modem, const char* stkCmdPdu )
                           stkCmdPdu); //string type in hexadecimal character format
 }
 
+void
+amodem_send_ussd_unsol_response( AModem  modem, int type, const char*  message )
+{
+    amodem_unsol( modem, "+CUSD: %d,\"%s\"\r", type, message );
+}
+
 static void
 amodem_send_calls_update( AModem  modem )
 {

--- a/telephony/android_modem.h
+++ b/telephony/android_modem.h
@@ -226,6 +226,7 @@ extern int    amodem_update_call( AModem  modem, const char*  number, ACallState
 extern int    amodem_disconnect_call( AModem  modem, const char*  number );
 extern int    amodem_remote_call_busy( AModem  modem, const char*  number );
 extern void   amodem_send_stk_unsol_proactive_command( AModem  modem, const char*  stkCmdPdu );
+extern void   amodem_send_ussd_unsol_response( AModem  modem, int type, const char*  message );
 
 /** Cell Location
  **/


### PR DESCRIPTION
Please see [bug 1007535](https://bugzilla.mozilla.org/show_bug.cgi?id=1007535).

This patch add a new console command to generate ussd unsolicited response.

`ussd unsol <type> <message_str>`

The possible value of `type`:
- **0**: no further user action required
- **1**: further user action required
- **2**: USSD terminated bu network
- **3**: other local client has responded
- **4**: operation not supported
- **5**: network time out

`message_str`: ussd message, a string type.
