### PR TITLE
Bug 944299 -Send CommandCompleteEvt with opcode when receving HCI_RESET

### DIFF
--- a/hw/bt-hci.c
+++ b/hw/bt-hci.c
@@ -1843,6 +1843,7 @@ static void bt_submit_hci(struct HCIInfo *info,
 
     case cmd_opcode_pack(OGF_HOST_CTL, OCF_RESET):
         bt_hci_reset(hci);
+        hci->last_cmd = cpu_to_le16(cmd);
         bt_hci_event_complete_status(hci, HCI_SUCCESS);
         break;
 


### PR DESCRIPTION
In Bluetooth core spec, HCI commands and Events, HCI_Reset:
"When the reset has been performed, a Command Complete event shall be
generated." bt-hci shall not reply Command Status event. We shall also
keep the last HCI command and put into Command Complete Event. Otherwise,
this invalid EventStatus event will be thrown away by bluedroid stack.
