### PR TITLE
Bug 1051715 - [Telephony] Show correct phone number in temporary mode clir

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -3100,6 +3100,11 @@ handleDial( const char*  cmd, AModem  modem )
     len  = strlen(cmd);
     if (len > 0 && cmd[len-1] == ';')
         len--;
+
+    /* clir */
+    if (len > 0 && (cmd[len-1] == 'I' || cmd[len-1] == 'i'))
+        len--;
+
     if (len >= sizeof(call->number))
         len = sizeof(call->number)-1;
 


### PR DESCRIPTION
Bug 1051715 - [Telephony] Show correct phone number in temporary mode clir

When making a call with temporary mode clir, reference-ril adds 'i' or 'I' after the number. We should get rid of that in emulator modem. Otherwise, the number will not be a valid string because it contains the illegal character.
