### PR TITLE
Bug 1103731 - Fail a dial request when failing to automatically hold the existing call 

### DIFF
--- a/android/console.c
+++ b/android/console.c
@@ -1752,6 +1752,27 @@ do_gsm_report( ControlClient  client, char*  args )
     return 0;
 }
 
+static int
+do_gsm_enable_disable( ControlClient  client, char  *args, bool enable )
+{
+    if (strcmp( args, "hold" ) == 0)
+        return amodem_set_feature(client->modem, A_MODEM_FEATURE_HOLD, enable);
+
+    return -1;
+}
+
+static int
+do_gsm_enable( ControlClient  client, char  *args )
+{
+    return do_gsm_enable_disable(client, args, true);
+}
+
+static int
+do_gsm_disable( ControlClient  client, char  *args )
+{
+    return do_gsm_enable_disable(client, args, false);
+}
+
 #if 0
 static const CommandDefRec  gsm_in_commands[] =
 {
@@ -1856,6 +1877,14 @@ static const CommandDefRec  gsm_commands[] =
     "'gsm report'      report all known fields\r\n"
     "'gsm report creg' report CREG field\r\n",
     NULL, do_gsm_report, NULL},
+
+    { "enable", "enable selected modem feature",
+    "'gsm enable hold' enable the hold feature\r\n",
+    NULL, do_gsm_enable, NULL},
+
+    { "disable", "disable selected modem feature",
+    "'gsm disable hold' disable the hold feature\r\n",
+    NULL, do_gsm_disable, NULL},
 
     { NULL, NULL, NULL, NULL, NULL, NULL }
 };

--- a/telephony/android_modem.h
+++ b/telephony/android_modem.h
@@ -239,6 +239,15 @@ extern void amodem_set_gsm_location( AModem modem, int lac, int ci );
 extern int amodem_get_base_port( AModem  modem );
 extern int amodem_get_instance_id( AModem  modem );
 
+/** Enable/Disable the selected modem feature
+ **/
+
+typedef enum {
+    A_MODEM_FEATURE_HOLD = (0x01 << 0)
+} AModemFeature;
+
+extern int amodem_set_feature( AModem  modem, AModemFeature  feature, bool  enable );
+
 /**/
 
 #endif /* _android_modem_h_ */


### PR DESCRIPTION
In this patch, I add a new command to enable/disable the hold feature of a modem, and slightly refactor a function in android_modem.c.