### PR TITLE
 Bug 1133400 - Fix an implemtation defect of emualtor 'modem enable|disable <feature>'. r=echen

### DIFF
--- a/android/console.c
+++ b/android/console.c
@@ -1776,18 +1776,29 @@ do_gsm_enable_disable( ControlClient  client, char  *args, bool enable )
     if (strcmp( args, "hold" ) == 0)
         return amodem_set_feature(client->modem, A_MODEM_FEATURE_HOLD, enable);
 
+    control_write( client, "KO: '%s' cannot be enabled or disabled.\r\n", args );
     return -1;
 }
 
 static int
 do_gsm_enable( ControlClient  client, char  *args )
 {
+    if (!args) {
+        control_write( client, "KO: missing argument, try 'gsm enable <feature>'\r\n" );
+        return -1;
+    }
+
     return do_gsm_enable_disable(client, args, true);
 }
 
 static int
 do_gsm_disable( ControlClient  client, char  *args )
 {
+    if (!args) {
+        control_write( client, "KO: missing argument, try 'gsm disable <feature>'\r\n" );
+        return -1;
+    }
+
     return do_gsm_enable_disable(client, args, false);
 }
 


### PR DESCRIPTION
There are two things to be fixed. First, we should check whether the argument is passed before we compare it with feature strings(e.g., "hold"). Second, if the passed argument doesn't match any feature strings, it would be nice to print an error message.