### PR TITLE
Bug 1139841 - Marionette webapi test failure in test_incoming.js, test_outgoing.js, test_incoming_delete.js, test_outgoing_delete.js, test_incoming_max_segments.js and test_massive_incoming_delete.js

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -912,11 +912,12 @@ _amodem_set_radio_state( AModem modem, ARadioState radio_state )
         case A_RADIO_STATE_OFF:
             amodem_set_voice_registration(modem, A_REGISTRATION_UNREGISTERED);
             amodem_set_data_registration(modem, A_REGISTRATION_UNREGISTERED);
-            asimcard_reset_status_after_radio_off(modem->sim);
+            asimcard_set_sim_power(modem->sim, false);
             break;
         case A_RADIO_STATE_ON:
             amodem_set_voice_registration(modem, A_REGISTRATION_HOME);
             amodem_set_data_registration(modem, A_REGISTRATION_HOME);
+            asimcard_set_sim_power(modem->sim, true);
             break;
     }
 

--- a/telephony/sim_card.c
+++ b/telephony/sim_card.c
@@ -1141,6 +1141,11 @@ asimcard_io( ASimCard  sim, const char*  cmd )
 
     assert( memcmp( cmd, "+CRSM=", 6 ) == 0 );
 
+    if ( sim->status == A_SIM_STATUS_ABSENT) {
+        // SIM not inserted
+        return "+CME ERROR: 10";
+    }
+
     if ( sscanf(cmd, "+CRSM=%d,%d,%d,%d,%d,%s", &command, &id, &p1, &p2, &p3, data) >= 5 ) {
         switch (command) {
             case A_SIM_CMD_GET_RESPONSE:

--- a/telephony/sim_card.c
+++ b/telephony/sim_card.c
@@ -128,14 +128,18 @@ asimcard_set_status( ASimCard  sim, ASimStatus  status )
 }
 
 void
-asimcard_reset_status_after_radio_off( ASimCard  sim )
+asimcard_set_sim_power( ASimCard  sim, bool  enabled )
 {
-    if (sim->status != A_SIM_STATUS_READY) {
-        return;
-    }
+    if (enabled) {
+        if (sim->status != A_SIM_STATUS_ABSENT) {
+            // Do nothing if sim is already powered on.
+            return;
+        }
 
-    if (sim->pin_enabled) {
-        sim->status = A_SIM_STATUS_PIN;
+        sim->status = sim->pin_enabled ? A_SIM_STATUS_PIN
+                                       : A_SIM_STATUS_READY;
+    } else {
+        sim->status = A_SIM_STATUS_ABSENT;
     }
 }
 

--- a/telephony/sim_card.h
+++ b/telephony/sim_card.h
@@ -34,7 +34,7 @@ typedef enum {
 
 extern ASimStatus  asimcard_get_status( ASimCard  sim );
 extern void        asimcard_set_status( ASimCard  sim, ASimStatus  status );
-extern void        asimcard_reset_status_after_radio_off( ASimCard  sim );
+extern void        asimcard_set_sim_power( ASimCard  sim, bool  enabled );
 
 extern const char*  asimcard_get_pin( ASimCard  sim );
 extern const char*  asimcard_get_puk( ASimCard  sim );


### PR DESCRIPTION
Please see [bug 1139841](https://bugzilla.mozilla.org/show_bug.cgi?id=1139841).