### PR TITLE
Bug 1067629 - Turn off radio control in System App when running test script for MozMobileConnection.SetRadioEnabled(false)

### DIFF
--- a/android/console.c
+++ b/android/console.c
@@ -3494,11 +3494,46 @@ do_modem_tech( ControlClient client, char* args )
     return 0;
 }
 
+static int
+do_modem_radio( ControlClient client, char *args )
+{
+    if (!client->modem) {
+        control_write(client, "KO: modem emulation not running\r\n");
+        return -1;
+    }
+
+    if (!args) {
+        ARadioState state = amodem_get_radio_state(client->modem);
+        control_write(client, "%s\r\n",
+                      state == A_RADIO_STATE_OFF ? "disabled" : "enabled");
+        return 0;
+    }
+
+    if (!strcmp(args, "enable")) {
+        amodem_set_radio_state(client->modem, A_RADIO_STATE_ON);
+        return 0;
+    }
+
+    if (!strcmp(args, "disable")) {
+        amodem_set_radio_state(client->modem, A_RADIO_STATE_OFF);
+        return 0;
+    }
+
+    control_write(client, "KO: invalid argument, try 'modem radio [enable|disable]'\r\n");
+    return -1;
+}
+
 static const CommandDefRec  modem_commands[] =
 {
     { "tech", "query/switch modem technology",
       NULL, help_modem_tech,
       do_modem_tech, NULL },
+
+    { "radio", "query/switch radio state",
+      "'modem radio': allows you to display the current radio state of emulator modem.\r\n"
+      "'modem radio enable': allows you to enable the radio of emulator modem.\r\n"
+      "'modem radio disable': allows you to disable the radio of emulator modem.\r\n",
+      NULL, do_modem_radio, NULL },
 
     { NULL, NULL, NULL, NULL, NULL, NULL }
 };

--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -876,6 +876,51 @@ amodem_get_radio_state( AModem modem )
     return modem->radio_state;
 }
 
+static int
+_amodem_set_radio_state( AModem modem, ARadioState radio_state )
+{
+    if (modem->radio_state == radio_state) {
+        // Indicate the radio state remains the same
+        return 0;
+    }
+
+    modem->radio_state = radio_state;
+    switch (radio_state) {
+        case A_RADIO_STATE_OFF:
+            amodem_set_voice_registration(modem, A_REGISTRATION_UNREGISTERED);
+            amodem_set_data_registration(modem, A_REGISTRATION_UNREGISTERED);
+            asimcard_reset_status_after_radio_off(modem->sim);
+            break;
+        case A_RADIO_STATE_ON:
+            amodem_set_voice_registration(modem, A_REGISTRATION_HOME);
+            amodem_set_data_registration(modem, A_REGISTRATION_HOME);
+            break;
+    }
+
+    // Indicate the radio state has being changed
+    return 1;
+}
+
+void
+amodem_set_radio_state( AModem modem, ARadioState radio_state )
+{
+    if (!_amodem_set_radio_state(modem, radio_state)) {
+        return;
+    }
+
+    /* The two unsolicited AT reponses are customized for testing purposes, and
+     * both of them are not defined in TS 27.007. They are made by extending the
+     * response of +CFUN? to become unsolicited. */
+    switch (radio_state) {
+        case A_RADIO_STATE_OFF:
+            amodem_unsol( modem, "+CFUN: 0");
+            break;
+        case A_RADIO_STATE_ON:
+            amodem_unsol( modem, "+CFUN: 1");
+            break;
+    }
+}
+
 ASimCard
 amodem_get_sim( AModem  modem )
 {
@@ -1912,24 +1957,8 @@ handleRadioPower( const char*  cmd, AModem  modem )
         return "+CME ERROR: 50";
     }
 
-    if (radio_state == modem->radio_state) {
-        return "OK";
-    }
-
-    modem->radio_state = radio_state;
     amodem_reply(modem, "OK");
-
-    switch (radio_state) {
-        case A_RADIO_STATE_OFF:
-            amodem_set_voice_registration(modem, A_REGISTRATION_UNREGISTERED);
-            amodem_set_data_registration(modem, A_REGISTRATION_UNREGISTERED);
-            asimcard_reset_status_after_radio_off(modem->sim);
-            break;
-        case A_RADIO_STATE_ON:
-            amodem_set_voice_registration(modem, A_REGISTRATION_HOME);
-            amodem_set_data_registration(modem, A_REGISTRATION_HOME);
-            break;
-    }
+    _amodem_set_radio_state(modem, radio_state);
 
     // Return NULL to show we have sent the reply and no further work to do.
     return NULL;

--- a/telephony/android_modem.h
+++ b/telephony/android_modem.h
@@ -45,6 +45,7 @@ typedef enum {
 } ARadioState;
 
 extern ARadioState  amodem_get_radio_state( AModem modem );
+extern void         amodem_set_radio_state( AModem modem, ARadioState state );
 
 /* Get the received signal strength indicator and bit error rate */
 extern void         amodem_get_signal_strength( AModem modem, int* rssi, int* ber );


### PR DESCRIPTION
The pull request is for uplifting patches to v2.2