### PR TITLE
Bug 1163483 - [emulator-l] [emulator-x86-l] reconsider the number of rild enabled

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -23,11 +23,12 @@ $(LOCAL_INSTALLED_MODULE): $(LOCAL_BUILT_MODULE)
 	@echo Install dir: $(HOST_OUT); \
 	tar -xvz -f $(abspath $<) -C $(HOST_OUT)
 
+EMULATOR_MULTI_SIM ?= 1
 EMULATOR_STANDALONE_ARCHIVE := $(EMULATOR_OUT)/emulator-standalone.tar.gz
 
 .PHONY: $(LOCAL_BUILT_MODULE)
 $(LOCAL_BUILT_MODULE):
-	$(EMULATOR_PATH)/android-configure.sh --out-dir=$(EMULATOR_OUT) --verbose --no-tests && \
+	$(EMULATOR_PATH)/android-configure.sh --multisim=$(EMULATOR_MULTI_SIM) --out-dir=$(EMULATOR_OUT) --verbose --no-tests && \
 	$(MAKE) -C $(EMULATOR_PATH) && \
 	rm -f $(EMULATOR_STANDALONE_ARCHIVE) && \
 	tar -cvzP -f $(EMULATOR_STANDALONE_ARCHIVE) -C $(EMULATOR_OUT) --transform='s,^$(EMULATOR_OUT)/emulator,bin/emulator,' --show-transformed-names $(EMULATOR_OUT)/emulator* lib lib64 && \

--- a/Makefile.android
+++ b/Makefile.android
@@ -58,7 +58,7 @@ MY_LD  := $(HOST_LD)
 MY_AR  := $(HOST_AR)
 MY_WINDRES := $(HOST_WINDRES)
 
-MY_CFLAGS := -g -falign-functions=0
+MY_CFLAGS := -g -falign-functions=0 $(QEMU_CONFIG_INCLUDES)
 ifeq ($(BUILD_DEBUG_EMULATOR),true)
     MY_CFLAGS += -O0
 else

--- a/android/config/darwin-x86/config-host.h
+++ b/android/config/darwin-x86/config-host.h
@@ -16,4 +16,3 @@
 #define CONFIG_ANDROID       1
 #define CONFIG_POSIX 1
 #define CONFIG_MADVISE 1
-#define MAX_GSM_DEVICES  9

--- a/android/config/freebsd-x86/config-host.h
+++ b/android/config/freebsd-x86/config-host.h
@@ -15,4 +15,3 @@
 #define CONFIG_ANDROID 1
 #define CONFIG_POSIX 1
 #define CONFIG_MADVISE 1
-#define MAX_GSM_DEVICES  9

--- a/android/config/linux-ppc/config-host.h
+++ b/android/config/linux-ppc/config-host.h
@@ -16,4 +16,3 @@
 #define CONFIG_POSIX 1
 #define CONFIG_ANDROID       1
 #define CONFIG_MADVISE 1
-#define MAX_GSM_DEVICES  9

--- a/android/config/linux-x86/config-host.h
+++ b/android/config/linux-x86/config-host.h
@@ -17,4 +17,3 @@
 #define CONFIG_SIGNALFD 1
 #define CONFIG_ANDROID       1
 #define CONFIG_MADVISE 1
-#define MAX_GSM_DEVICES  9

--- a/android/config/windows/config-host.h
+++ b/android/config/windows/config-host.h
@@ -8,4 +8,3 @@
 #define QEMU_PKGVERSION "Android"
 #define CONFIG_WIN32   1
 #define CONFIG_ANDROID       1
-#define MAX_GSM_DEVICES  9


### PR DESCRIPTION
Please see [bug 1163483](https://bugzilla.mozilla.org/show_bug.cgi?id=1163483).
