### PR TITLE
Bug 1007535 - Add new console command, "ussd unsol", to generate USSD unsolicited response

### DIFF
--- a/telephony/android_modem.c
+++ b/telephony/android_modem.c
@@ -1416,6 +1416,16 @@ amodem_send_stk_unsol_proactive_command( AModem  modem, const char* stkCmdPdu )
                           stkCmdPdu); //string type in hexadecimal character format
 }
 
+void
+amodem_send_ussd_unsol_response( AModem  modem, int type, const char*  message )
+{
+    if (message) {
+        amodem_unsol( modem, "+MCUSD: %d,\"%s\"\r", type, message );
+    } else {
+        amodem_unsol( modem, "+MCUSD: %d\r", type);
+    }
+}
+
 static void
 amodem_send_calls_update( AModem  modem )
 {

--- a/telephony/android_modem.h
+++ b/telephony/android_modem.h
@@ -233,6 +233,7 @@ extern int    amodem_disconnect_call( AModem  modem, const char*  number );
 extern int    amodem_remote_call_busy( AModem  modem, const char*  number );
 extern void   amodem_send_stk_unsol_proactive_command( AModem  modem, const char*  stkCmdPdu );
 extern int    amodem_accept_call( AModem  modem, const char*  number );
+extern void   amodem_send_ussd_unsol_response( AModem  modem, int type, const char*  message );
 
 /** Cell Location
  **/


### PR DESCRIPTION
Please see [bug 1007535](https://bugzilla.mozilla.org/show_bug.cgi?id=1007535).

This patch add a new console command to generate ussd unsolicited response.

`ussd unsol <type> <message_str>`

The possible value of `type`:
- **0**: no further user action required
- **1**: further user action required
- **2**: USSD terminated bu network
- **3**: other local client has responded
- **4**: operation not supported
- **5**: network time out

`message_str`: ussd message, a string type.
